### PR TITLE
Deep copying

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ keywords = ["neural", "network", "fann", "classifier", "backpropagation"]
 double = ["fann-sys/double"]
 
 [dependencies]
-fann-sys = "0.1.7"
+fann-sys = "0.1.8"
 libc = "~0.2.20"

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,8 +91,8 @@ pub type FannResult<T> = Result<T, FannError>;
 
 impl fmt::Display for FannError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        try!(self.error_type.fmt(f));
-        try!(": ".fmt(f));
+        self.error_type.fmt(f)?;
+        ": ".fmt(f)?;
         self.error_str.fmt(f)
     }
 }
@@ -147,7 +147,7 @@ impl FannError {
         errdat: *mut fann_error,
         error_str: &str,
     ) -> FannResult<()> {
-        try!(FannError::check_no_error(errdat));
+        FannError::check_no_error(errdat)?;
         match result {
             0 => Ok(()),
             _ => Err(FannError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl CallbackResult {
 pub struct FannTrainer<'a> {
     fann: &'a mut Fann,
     cur_data: CurrentTrainData<'a>,
-    callback: Option<&'a Fn(&Fann, &TrainData, c_uint) -> CallbackResult>,
+    callback: Option<&'a dyn Fn(&Fann, &TrainData, c_uint) -> CallbackResult>,
     interval: c_uint,
     cascade: bool,
 }
@@ -204,7 +204,7 @@ impl<'a> FannTrainer<'a> {
     pub fn with_callback(
         self,
         interval: c_uint,
-        callback: &'a Fn(&Fann, &TrainData, c_uint) -> CallbackResult,
+        callback: &'a dyn Fn(&Fann, &TrainData, c_uint) -> CallbackResult,
     ) -> FannTrainer<'a> {
         FannTrainer {
             callback: Some(callback),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,6 +382,7 @@ impl Fann {
     }
 
     /// Create a deep copy of a neural network.
+    ///
     /// The `Clone` trait is intentionally not implemented, because this operation might fail.
     pub fn try_clone(&self) -> FannResult<Fann> {
         unsafe { Fann::from_raw(fann_copy(self.raw)) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,12 @@ impl Fann {
         unsafe { Fann::from_raw(fann_create_from_file(filename.as_ptr())) }
     }
 
+    /// Create a deep copy of a neural network.
+    /// The `Clone` trait is intentionally not implemented, because this operation might fail.
+    pub fn try_clone(&self) -> FannResult<Fann> {
+        unsafe { Fann::from_raw(fann_copy(self.raw)) }
+    }
+
     /// Save the network to a configuration file.
     ///
     /// The file will contain all information about the neural network, except parameters generated

--- a/src/train_data.rs
+++ b/src/train_data.rs
@@ -36,10 +36,10 @@ impl TrainData {
     /// outputdata separated by space
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P) -> FannResult<TrainData> {
-        let filename = try!(to_filename(path));
+        let filename = to_filename(path)?;
         unsafe {
             let raw = fann_read_train_from_file(filename.as_ptr());
-            try!(FannError::check_no_error(raw as *mut fann_error));
+            FannError::check_no_error(raw as *mut fann_error)?;
             Ok(TrainData { raw })
         }
     }
@@ -81,17 +81,17 @@ impl TrainData {
             );
             // Remove it from the thread-local container to free the memory.
             CALLBACK.with(|cell| *cell.borrow_mut() = None);
-            try!(FannError::check_no_error(raw as *mut fann_error));
+            FannError::check_no_error(raw as *mut fann_error)?;
             Ok(TrainData { raw })
         }
     }
 
     /// Save the training data to a file.
     pub fn save<P: AsRef<Path>>(&self, path: P) -> FannResult<()> {
-        let filename = try!(to_filename(path));
+        let filename = to_filename(path)?;
         unsafe {
             let result = fann_save_train(self.raw, filename.as_ptr());
-            try!(FannError::check_no_error(self.raw as *mut fann_error));
+            FannError::check_no_error(self.raw as *mut fann_error)?;
             if result == -1 {
                 Err(FannError {
                     error_type: FannErrorType::CantSaveFile,
@@ -107,7 +107,7 @@ impl TrainData {
     pub fn merge(data1: &TrainData, data2: &TrainData) -> FannResult<TrainData> {
         unsafe {
             let raw = fann_merge_train_data(data1.raw, data2.raw);
-            try!(FannError::check_no_error(raw as *mut fann_error));
+            FannError::check_no_error(raw as *mut fann_error)?;
             Ok(TrainData { raw })
         }
     }
@@ -117,7 +117,7 @@ impl TrainData {
     pub fn subset(&self, pos: c_uint, length: c_uint) -> FannResult<TrainData> {
         unsafe {
             let raw = fann_subset_train_data(self.raw, pos, length);
-            try!(FannError::check_no_error(raw as *mut fann_error));
+            FannError::check_no_error(raw as *mut fann_error)?;
             Ok(TrainData { raw })
         }
     }
@@ -142,7 +142,7 @@ impl TrainData {
     pub fn scale_for(&mut self, fann: &Fann) -> FannResult<()> {
         unsafe {
             fann_scale_train(fann.raw, self.raw);
-            try!(FannError::check_no_error(fann.raw as *mut fann_error));
+            FannError::check_no_error(fann.raw as *mut fann_error)?;
             FannError::check_no_error(self.raw as *mut fann_error)
         }
     }
@@ -152,7 +152,7 @@ impl TrainData {
     pub fn descale_for(&mut self, fann: &Fann) -> FannResult<()> {
         unsafe {
             fann_descale_train(fann.raw, self.raw);
-            try!(FannError::check_no_error(fann.raw as *mut fann_error));
+            FannError::check_no_error(fann.raw as *mut fann_error)?;
             FannError::check_no_error(self.raw as *mut fann_error)
         }
     }

--- a/src/train_data.rs
+++ b/src/train_data.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::ptr::copy_nonoverlapping;
 
-pub type TrainCallback = Fn(c_uint) -> (Vec<fann_type>, Vec<fann_type>);
+pub type TrainCallback = dyn Fn(c_uint) -> (Vec<fann_type>, Vec<fann_type>);
 
 // Thread-local container for user-supplied callback functions.
 // This is necessary because the raw fann_create_train_from_callback C function takes a function


### PR DESCRIPTION
This PR implements the Fann::try_clone() function.
It **does not** work in its current form, because it depends on the other PR in fann_sys. The ideal solution would be to update fann_sys on crates.io, then update fann to point to that version.